### PR TITLE
rebase to resolute, stop ingesting from ppa as it is not maintained

### DIFF
--- a/.github/workflows/external_trigger.yml
+++ b/.github/workflows/external_trigger.yml
@@ -29,7 +29,7 @@ jobs:
           echo "> [!NOTE]" >> $GITHUB_STEP_SUMMARY
           echo "> External trigger running off of master branch. To disable this trigger, add \`remmina_master\` into the Github organizational variable \`SKIP_EXTERNAL_TRIGGER\`." >> $GITHUB_STEP_SUMMARY
           printf "\n## Retrieving external version\n\n" >> $GITHUB_STEP_SUMMARY
-          EXT_RELEASE=$(curl -sX GET http://ppa.launchpad.net/remmina-ppa-team/remmina-next/ubuntu/dists/noble/main/binary-amd64/Packages.gz | gunzip |grep -A 7 -m 1 'Package: remmina' | awk -F ': ' '/Version/{print $2;exit}')
+          EXT_RELEASE=$(curl -s -L https://archive.ubuntu.com/ubuntu/dists/resolute/universe/binary-amd64/Packages.gz | gunzip |grep -A 7 -m 1 'Package: remmina' | awk -F ': ' '/Version/{print $2;exit}')
           echo "Type is \`custom_version_command\`" >> $GITHUB_STEP_SUMMARY
           if grep -q "^remmina_master_${EXT_RELEASE}" <<< "${SKIP_EXTERNAL_TRIGGER}"; then
             echo "> [!WARNING]" >> $GITHUB_STEP_SUMMARY

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM ghcr.io/linuxserver/baseimage-selkies:ubuntunoble
+FROM ghcr.io/linuxserver/baseimage-selkies:ubunturesolute
 
 # set version label
 ARG BUILD_DATE
@@ -11,7 +11,6 @@ LABEL maintainer="thelamer"
 
 # title
 ENV TITLE=Remmina \
-    NO_GAMEPAD=true \
     PIXELFLUX_WAYLAND=true
 
 RUN \
@@ -20,7 +19,6 @@ RUN \
     /usr/share/selkies/www/icon.png \
     https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/remmina-logo.png && \
   echo "**** install remmina ****" && \
-  apt-add-repository ppa:remmina-ppa-team/remmina-next && \
   apt-get update && \
   apt-get install -y \
     librsvg2-common \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM ghcr.io/linuxserver/baseimage-selkies:arm64v8-ubuntunoble
+FROM ghcr.io/linuxserver/baseimage-selkies:arm64v8-ubunturesolute
 
 # set version label
 ARG BUILD_DATE
@@ -11,7 +11,6 @@ LABEL maintainer="thelamer"
 
 # title
 ENV TITLE=Remmina \
-    NO_GAMEPAD=true \
     PIXELFLUX_WAYLAND=true
 
 RUN \
@@ -20,7 +19,6 @@ RUN \
     /usr/share/selkies/www/icon.png \
     https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/remmina-logo.png && \
   echo "**** install remmina ****" && \
-  apt-add-repository ppa:remmina-ppa-team/remmina-next && \
   apt-get update && \
   apt-get install -y \
     librsvg2-common \

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -33,6 +33,7 @@ pipeline {
     CI_PORT = '3001'
     CI_SSL = 'true'
     CI_DELAY = '120'
+    CI_WEB_SCREENSHOT_DELAY = '30'
     CI_DOCKERENV = ''
     CI_AUTH = ''
     CI_WEBPATH = ''
@@ -149,7 +150,7 @@ pipeline {
       steps{
         script{
           env.EXT_RELEASE = sh(
-            script: ''' curl -sX GET http://ppa.launchpad.net/remmina-ppa-team/remmina-next/ubuntu/dists/noble/main/binary-amd64/Packages.gz | gunzip |grep -A 7 -m 1 'Package: remmina' | awk -F ': ' '/Version/{print $2;exit}' ''',
+            script: ''' curl -s -L https://archive.ubuntu.com/ubuntu/dists/resolute/universe/binary-amd64/Packages.gz | gunzip |grep -A 7 -m 1 'Package: remmina' | awk -F ': ' '/Version/{print $2;exit}' ''',
             returnStdout: true).trim()
             env.RELEASE_LINK = 'custom_command'
         }
@@ -894,6 +895,7 @@ pipeline {
                 --shm-size=1gb \
                 -v /var/run/docker.sock:/var/run/docker.sock \
                 -e IMAGE=\"${IMAGE}\" \
+                -e WEB_SCREENSHOT_DELAY=\"${CI_WEB_SCREENSHOT_DELAY}\" \
                 -e DOCKER_LOGS_TIMEOUT=\"${CI_DELAY}\" \
                 -e TAGS=\"${CI_TAGS}\" \
                 -e META_TAG=\"${META_TAG}\" \

--- a/README.md
+++ b/README.md
@@ -643,6 +643,7 @@ Once registered you can define the dockerfile to use with `-f Dockerfile.aarch64
 
 ## Versions
 
+* **20.06.26:** - Rebase to resolute, stop ingesting from ppa.
 * **04.04.26:** - Make Wayland default disable with PIXELFLUX_WAYLAND=false.
 * **28.12.25:** - Add Wayland init logic.
 * **14.08.25:** - Ingest from PPA.

--- a/jenkins-vars.yml
+++ b/jenkins-vars.yml
@@ -3,7 +3,7 @@
 # jenkins variables
 project_name: docker-remmina
 external_type: na
-custom_version_command: "curl -sX GET http://ppa.launchpad.net/remmina-ppa-team/remmina-next/ubuntu/dists/noble/main/binary-amd64/Packages.gz | gunzip |grep -A 7 -m 1 'Package: remmina' | awk -F ': ' '/Version/{print $2;exit}'"
+custom_version_command: "curl -s -L https://archive.ubuntu.com/ubuntu/dists/resolute/universe/binary-amd64/Packages.gz | gunzip |grep -A 7 -m 1 'Package: remmina' | awk -F ': ' '/Version/{print $2;exit}'"
 release_type: stable
 release_tag: latest
 ls_branch: master
@@ -23,6 +23,7 @@ repo_vars:
   - CI_PORT = '3001'
   - CI_SSL = 'true'
   - CI_DELAY = '120'
+  - CI_WEB_SCREENSHOT_DELAY = '30'
   - CI_DOCKERENV = ''
   - CI_AUTH = ''
   - CI_WEBPATH = ''

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -105,6 +105,7 @@ init_diagram: |
   "remmina:latest" <- Base Images
 # changelog
 changelogs:
+  - {date: "20.06.26:", desc: "Rebase to resolute, stop ingesting from ppa."}
   - {date: "04.04.26:", desc: "Make Wayland default disable with PIXELFLUX_WAYLAND=false."}
   - {date: "28.12.25:", desc: "Add Wayland init logic."}
   - {date: "14.08.25:", desc: "Ingest from PPA."}


### PR DESCRIPTION
Basic resolute rebase, I waited a while to see if they would add resolute to their remmina next ppa but it looks like it lacks a maintainer. This just ingests the latest version from Resolute. 